### PR TITLE
Switch AQI Icon to value, Add Pop-up Description to Air Quality Card

### DIFF
--- a/healthapp/lib/backend/air/airQuality.dart
+++ b/healthapp/lib/backend/air/airQuality.dart
@@ -16,8 +16,10 @@ class AirQualityData {
       airQualityStatus = "Good";
     } else if (aqi <= 100) {
       airQualityStatus = "Moderate";
+    } else if (aqi <= 300 && aqi > 100) {
+      airQualityStatus = "Unhealthy";
     } else {
-      airQualityStatus = "Poor";
+      airQualityStatus = "Hazardous";
     }
   }
 

--- a/healthapp/lib/dashboard/dashboard_cards/air_quality_card.dart
+++ b/healthapp/lib/dashboard/dashboard_cards/air_quality_card.dart
@@ -3,6 +3,8 @@ import 'dart:developer';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:healthapp/backend/location/location.dart';
+import 'package:healthapp/util/dialogs/error_dialog.dart';
+import 'package:healthapp/util/dialogs/information_dialog.dart';
 import '../../bloc/air_quality_bloc.dart';
 import '../dashboard_card.dart';
 
@@ -53,34 +55,52 @@ class AirQualityCard extends StatelessWidget {
         return DashboardCard(
           flex: 5,
           color: lightBlue,
-          child: Center(
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Text("Air quality",
-                    style: TextStyle(
-                        shadows: [textShadow],
-                        color: Colors.white,
-                        fontSize: 15)),
-                const Image(
-                  image: AssetImage('assets/images/wind_white.png'),
-                  width: 60,
-                ),
-                ShaderMask(
-                  shaderCallback: (bounds) => LinearGradient(
-                    colors: getQualityColor(state.airQualityStatus ?? ""),
-                  ).createShader(bounds),
-                  child: Text(
-                    state.airQualityStatus ?? "",
+          child: GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: () {
+              showInformationDialog(
+                  context, "About weather quality", aqiInformation);
+            },
+            child: Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(
+                    "Air quality",
                     style: TextStyle(
                       shadows: [textShadow],
-                      fontWeight: FontWeight.bold,
-                      fontSize: 25.0,
                       color: Colors.white,
+                      fontSize: 15,
                     ),
                   ),
-                )
-              ],
+                  Text(
+                    state.airQuality.toString(),
+                    style: TextStyle(
+                        shadows: [textShadow],
+                        fontWeight: FontWeight.bold,
+                        fontSize: 25.0,
+                        color: Colors.white),
+                  ),
+                  /* const Image(
+                    image: AssetImage('assets/images/wind_white.png'),
+                    width: 60,
+                  ), */
+                  ShaderMask(
+                    shaderCallback: (bounds) => LinearGradient(
+                      colors: getQualityColor(state.airQualityStatus ?? ""),
+                    ).createShader(bounds),
+                    child: Text(
+                      state.airQualityStatus ?? "",
+                      style: TextStyle(
+                        shadows: [textShadow],
+                        fontWeight: FontWeight.bold,
+                        fontSize: 25.0,
+                        color: Colors.white,
+                      ),
+                    ),
+                  )
+                ],
+              ),
             ),
           ), // CONTENT HERE
         );
@@ -93,3 +113,22 @@ class AirQualityCard extends StatelessWidget {
     });
   }
 }
+
+const String aqiInformation = '''
+AQI is a measure used to assess and communicate air pollution levels.
+
+It considers pollutants such as PM2.5, PM10, O3, CO, SO2, and NO2.
+
+AQI ranges from 0 to 500 or higher, indicating different air quality levels.
+
+Categories and associated health risks:
+- Good (0-50): Satisfactory air quality, minimal health risk.
+- Moderate (51-100): Acceptable air quality, some moderate health concerns for sensitive individuals.
+- Unhealthy for Sensitive Groups (101-150): Adverse effects on individuals with respiratory or heart conditions, children, and the elderly.
+- Unhealthy (151-200): Considered unhealthy, everyone may experience some adverse health effects.
+- Very Unhealthy (201-300): Significantly impaired air quality, increased health risks for the entire population.
+- Hazardous (301-500): Extremely poor air quality, severe health impacts, emergency conditions may be declared.
+
+AQI varies based on location and available monitoring stations.
+Local authorities provide real-time or periodic updates on the AQI to inform the public and advise precautions.
+''';

--- a/healthapp/lib/dashboard/dashboard_cards/air_quality_card.dart
+++ b/healthapp/lib/dashboard/dashboard_cards/air_quality_card.dart
@@ -26,19 +26,23 @@ class AirQualityCard extends StatelessWidget {
         {
           return const [Color(0xFF05FF00), Color(0xFF00FFFF)];
         }
-      case ("poor"):
-        {
-          return const [
-            Color.fromARGB(255, 252, 94, 94),
-            Color.fromARGB(255, 255, 141, 89)
-          ];
-        }
       case ("moderate"):
         {
           return const [
             Color.fromARGB(255, 255, 184, 78),
             Color.fromARGB(255, 255, 237, 73)
           ];
+        }
+      case ("unhealthy"):
+        {
+          return const [
+            Color.fromARGB(255, 252, 94, 94),
+            Color.fromARGB(255, 255, 141, 89)
+          ];
+        }
+      case ("hazardous"):
+        {
+          return const [Colors.black, Colors.grey];
         }
 
       default:
@@ -81,20 +85,16 @@ class AirQualityCard extends StatelessWidget {
                         fontSize: 25.0,
                         color: Colors.white),
                   ),
-                  /* const Image(
-                    image: AssetImage('assets/images/wind_white.png'),
-                    width: 60,
-                  ), */
+
                   ShaderMask(
                     shaderCallback: (bounds) => LinearGradient(
                       colors: getQualityColor(state.airQualityStatus ?? ""),
                     ).createShader(bounds),
                     child: Text(
                       state.airQualityStatus ?? "",
-                      style: TextStyle(
-                        shadows: [textShadow],
+                      style: const TextStyle(
                         fontWeight: FontWeight.bold,
-                        fontSize: 25.0,
+                        fontSize: 15.0,
                         color: Colors.white,
                       ),
                     ),

--- a/healthapp/lib/util/dialogs/generic_dialog.dart
+++ b/healthapp/lib/util/dialogs/generic_dialog.dart
@@ -14,7 +14,9 @@ Future<T?> showGenericDialog<T>({
     builder: (builder) {
       return AlertDialog(
         title: Text(title),
-        content: Text(content),
+        content: SingleChildScrollView(
+          child: Text(content),
+        ),
         actions: options.keys.map((optionTitle) {
           final T value = options[optionTitle];
           return TextButton(

--- a/healthapp/lib/util/dialogs/information_dialog.dart
+++ b/healthapp/lib/util/dialogs/information_dialog.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+import 'generic_dialog.dart';
+
+
+Future<void> showInformationDialog(
+  BuildContext context,
+  String title,
+  String text,
+) {
+  return showGenericDialog<void>(
+    context: context,
+    title: title,
+    content: text,
+    optionsBuilder: () => {
+      'OK': null,
+    },
+  );
+}


### PR DESCRIPTION
This pull request addresses two key changes in the Air Quality Card component. First, it removes the AQI (Air Quality Index) icon that previously displayed the value of AQI directly on the card. Second, it introduces a pop-up functionality that appears when the card is clicked, providing a description of what AQI is and its corresponding value ranges.

These changes contribute to a more streamlined and informative Air Quality Card component. By removing the direct display of AQI value and introducing the pop-up description, the user interface becomes more intuitive and educational. Users can now gain a better understanding of AQI and its value ranges, helping them make informed decisions regarding air quality.

Please review and consider merging this pull request to enhance the Air Quality Card component.

Thank you for your attention and feedback!